### PR TITLE
Change initial rsync from -v to --progress

### DIFF
--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -3,7 +3,7 @@
 echo "Starting Plex Media Server."
 home="$(echo ~plex)"
 
-rsync -av "${home}-persistent/" "$home"
+rsync -a --progress "${home}-persistent/" "$home"
 
 export PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR="${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR:-${home}/Library/Application Support}"
 export PLEX_MEDIA_SERVER_HOME=/usr/lib/plexmediaserver


### PR DESCRIPTION
Fixes #3  by removing verbose switch from the initial rsync (and adds --progress so that some progress can be shown, since these might be long syncs).