### PR TITLE
Moved .syncing status file and added file lock req.

### DIFF
--- a/root/etc/services.d/plex/sync
+++ b/root/etc/services.d/plex/sync
@@ -2,9 +2,10 @@
 
 echo "Syncing config directory."
 home="$(echo ~plex)"
+status_file="/etc/services.d/plex/.syncing"
 
-if [ -n "$SYNC-PERSISTENT" ] && [[ "$SYNC-PERSISTENT" == 'TRUE' ]] && [ ! -f "$home/.syncing" ]; then
-  touch "$home/.syncing"
-  rsync -av "$home/" "${home}-persistent"
-  rm "$home/.syncing"
+# Environment variable $SYNC-PERSISTENT must be set
+if [ ! -z ${SYNC-PERSISTENT+x} ]; then
+  flcok -n "$status_file" rsync -av "$home/" "${home}-persistent"
+  rm "$status_file"
 fi


### PR DESCRIPTION
Moved status file from /config/.syncing to
/etc/services.d/plex/.syncing

The status file is now also locked when syncing occurs; this will allow
for easier implementation of waiting to sync when the container exits
(see Issue #6).

Fixes #2 