### PR TITLE
Start cron when the binary is installed.

### DIFF
--- a/root/installBinary.sh
+++ b/root/installBinary.sh
@@ -27,3 +27,6 @@ if crontab -l 2> /dev/null; then
 else
   echo '*/5 * * * * /etc/services.d/plex/sync' | crontab -
 fi
+
+# Start cron
+service cron start


### PR DESCRIPTION
In previous versions, the cron service was never started.
Fixes #11 