### PR TITLE
Change sync frequency to 1 minute (from 5)

### DIFF
--- a/root/installBinary.sh
+++ b/root/installBinary.sh
@@ -23,9 +23,9 @@ fi
 
 # Add to crontab
 if crontab -l 2> /dev/null; then
-  echo "$(echo '*/5 * * * * /etc/services.d/plex/sync'; crontab -l)" | crontab -
+  echo "$(echo '*/1 * * * * /etc/services.d/plex/sync'; crontab -l)" | crontab -
 else
-  echo '*/5 * * * * /etc/services.d/plex/sync' | crontab -
+  echo '*/1 * * * * /etc/services.d/plex/sync' | crontab -
 fi
 
 # Start cron


### PR DESCRIPTION
More-frequent syncs will make it less likely that data is missed when the container is closed/killed; blocking is done by flock, so syncs are skipped rather than overlapping if they run > 1 minute.