### PR TITLE
Log output of rsync using s6-log.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
-    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing"
+    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing" \
+    SYNC_LOG_PATH="/var/log/plex_sync"
 
 ENTRYPOINT ["/init"]
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,7 +9,8 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
-    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing"
+    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing" \
+    SYNC_LOG_PATH="/var/log/plex_sync"
 
 ENTRYPOINT ["/init"]
 

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,8 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
-    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing"
+    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing" \
+    SYNC_LOG_PATH="/var/log/plex_sync"
 
 ENTRYPOINT ["/init"]
 

--- a/root/usr/local/bin/sync_and_log
+++ b/root/usr/local/bin/sync_and_log
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
 
-rsync -av "$1/" "$2" &> /dev/null
+rsync -av "$1/" "$2" | s6-log T "$SYNC_LOG_PATH"


### PR DESCRIPTION
All rsync calls through the sync_and_log script are now logged via s6-log.

Closes #10 