### PR TITLE
Add a script to check if $HOME_PERSISTENT is mounted, and use it consistently.

### DIFF
--- a/root/etc/services.d/plex/finish
+++ b/root/etc/services.d/plex/finish
@@ -2,4 +2,6 @@
 
 echo "Closing out Plex Media Server."
 
-flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME" "$HOME_PERSISTENT"
+if /usr/local/bin/home_persistent_mounted; then
+  flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME" "$HOME_PERSISTENT"
+fi

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -2,7 +2,9 @@
 
 echo "Starting Plex Media Server."
 
-flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME_PERSISTENT" "$HOME"
+if /usr/local/bin/home_persistent_mounted; then
+  flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME_PERSISTENT" "$HOME"
+fi
 
 export PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR="${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR:-${HOME}/Library/Application Support}"
 export PLEX_MEDIA_SERVER_HOME=/usr/lib/plexmediaserver

--- a/root/etc/services.d/plex_sync/run
+++ b/root/etc/services.d/plex_sync/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 # Loop and sync if $SYNC_PERSISTENT is set
-if [ ! -z ${SYNC_PERSISTENT+x} ]; then
+if /usr/local/bin/home_persistent_mounted; then
   while :
   do
     flock -n "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME" "$HOME_PERSISTENT"

--- a/root/usr/local/bin/home_persistent_mounted
+++ b/root/usr/local/bin/home_persistent_mounted
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bash
+
+# Compare some info from df to see if the /config_persistent exists and is mounted on the same filesystem as root.
+root_info=$(df | awk -v path="/" '{ if ( $6 == path ) print $2 ";" $3 ";" $4 }')
+home_persistent_info=$(df | awk -v path="$HOME_PERSISTENT" '{ if ( $6 == path ) print $2 ";" $3 ";" $4 }')
+[ ! -z ${home_persistent_info+x} ] && [ "$root_info" != "$home_persistent_info" ]
+exit $?


### PR DESCRIPTION
The scripts is now always checked before syncing is performed, and the SYNC_PERSISTENT environment variable is now no longer needed.

Closes #21 