### PR TITLE
Changed to correct the services directory so that plex_sync will run.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
-    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing" \
+    SYNC_STATUS_FILE="/etc/services.d/plex_sync/data/syncing" \
     SYNC_LOG_PATH="/var/log/plex_sync"
 
 ENTRYPOINT ["/init"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,7 +9,7 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
-    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing" \
+    SYNC_STATUS_FILE="/etc/services.d/plex_sync/data/syncing" \
     SYNC_LOG_PATH="/var/log/plex_sync"
 
 ENTRYPOINT ["/init"]

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,7 +9,7 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
-    SYNC_STATUS_FILE="/etc/services.d/plex_sync/.syncing" \
+    SYNC_STATUS_FILE="/etc/services.d/plex_sync/data/syncing" \
     SYNC_LOG_PATH="/var/log/plex_sync"
 
 ENTRYPOINT ["/init"]

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -3,10 +3,8 @@
 if /usr/local/bin/home_persistent_mounted; then
   echo "Syncing persistent files to the local installation."
   flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME_PERSISTENT" "$HOME"
-  echo "Sync to local installation complete."
-  echo "Starting persistent sync service."
-  services_dir="$(ps aux | awk '{ if ( $2 == 1 ) print $NF }'"
-  s6-svc -u "$services_dir/plex_sync"
+  echo "Sync to local installation complete; starting persistent sync service."
+  s6-svc -u "$(ps aux | awk '{ if ( $2 == 1 ) print $NF }')/plex_sync"
 fi
 
 echo "Starting Plex Media Server."

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -5,7 +5,8 @@ if /usr/local/bin/home_persistent_mounted; then
   flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME_PERSISTENT" "$HOME"
   echo "Sync to local installation complete."
   echo "Starting persistent sync service."
-  s6-svc -u "/etc/services.d/plex_sync"
+  services_dir="$(ps aux | awk '{ if ( $2 == 1 ) print $NF }'"
+  s6-svc -u "$services_dir/plex_sync"
 fi
 
 echo "Starting Plex Media Server."


### PR DESCRIPTION
Instead of trying to start `/etc/services.d/plex_sync` (which was incorrect), a needlessly-complex combination of ps and aux is used to find the live s6 services directory and start the plex_sync service.

Also the location of the syncing status file was changed once again to comply with s6 best practices (which recommend against putting anything in the services directories unless it's in ./data or ./env).