### PR TITLE
Use git to manage "snapshots" of the persistent config data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN \
       uuid-runtime \
       unrar \
       rsync \
+      git \
     && \
 
 # Fetch and extract S6 overlay

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -24,6 +24,7 @@ RUN \
       uuid-runtime \
       unrar \
       rsync \
+      git \
     && \
 
 # Fetch and extract S6 overlay

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -24,6 +24,7 @@ RUN \
       uuid-runtime \
       unrar \
       rsync \
+      git \
     && \
 
 # Fetch and extract S6 overlay

--- a/root/etc/services.d/plex/finish
+++ b/root/etc/services.d/plex/finish
@@ -4,5 +4,6 @@ echo "Closing out Plex Media Server."
 
 if /usr/local/bin/home_persistent_mounted; then
   flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME" "$HOME_PERSISTENT"
-  git -C "$HOME_PERSISTENT" commit --amend --allow-empty -m "clean $(date)" &> /dev/null
+  git -C "$HOME_PERSISTENT" add -A . &> /dev/null && \
+      git -C "$HOME_PERSISTENT" commit --amend --allow-empty -m "clean $(date)" &> /dev/null
 fi

--- a/root/etc/services.d/plex/finish
+++ b/root/etc/services.d/plex/finish
@@ -4,4 +4,5 @@ echo "Closing out Plex Media Server."
 
 if /usr/local/bin/home_persistent_mounted; then
   flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME" "$HOME_PERSISTENT"
+  git -C "$HOME_PERSISTENT" commit --amend --allow-empty -m "clean $(date)" &> /dev/null
 fi

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -1,9 +1,26 @@
 #!/usr/bin/with-contenv bash
 
 if /usr/local/bin/home_persistent_mounted; then
-  echo "Syncing persistent files to the local installation."
-  flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_and_log "$HOME_PERSISTENT" "$HOME"
-  echo "Sync to local installation complete; starting persistent sync service."
+  # Some git commands won't work without these.
+  git config --global user.name "plex"
+  git config --global user.email "no-reply@example.com"
+  if [ -d "$HOME_PERSISTENT/.git" ]; then
+    echo "Persistent config repo found; copying files to local installation."
+  else
+    echo "No repo found for the persistent config; creating."
+    # Create the repo and make an initial commit.
+    git -C "$HOME_PERSISTENT" init . &> /dev/null && \
+        git -C "$HOME_PERSISTENT" add -A . &> /dev/null && \
+        git -C "$HOME_PERSISTENT" commit --allow-empty -m "clean ${date}" &> /dev/null
+    echo "Repo created; copying files to local installation."
+  fi
+  # Remove the dirty files from the repo.
+  git -C "$HOME_PERSISTENT" reset --hard HEAD &> /dev/null && \
+      git -C "$HOME_PERSISTENT" clean -fdx &> /dev/null
+  # Copy the files.
+  /usr/local/bin/sync_and_log "$HOME_PERSISTENT" "$HOME"
+  # Start the sync service.
+  echo "Files copied to local installation; starting sync service."
   s6-svc -u "$(ps aux | awk '{ if ( $2 == 1 ) print $NF }')/plex_sync"
 fi
 

--- a/root/usr/local/bin/sync_and_log
+++ b/root/usr/local/bin/sync_and_log
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
 
-rsync -av "$1/" "$2" | s6-log T "$SYNC_LOG_PATH"
+rsync -av --exclude="/.git*" "$1/" "$2" | s6-log T "$SYNC_LOG_PATH"


### PR DESCRIPTION
The persistent data is stored in a git repo and given an initial commit. The plex service's finish script calls `git-commit --amend` to store the "clean" changes, and the service's run script calls `git-reset --hard` to get rid of any leftover dirty files.

Closes #26 