### PR TITLE
Add cron for periodic PMS restarts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
     SYNC_STATUS_FILE="/etc/services.d/plex/data/syncing"
+ENV PLEX_PORT=32400 \
+    X_PLEX_TOKEN= \
+    PERSISTENT_CONFIG_CRON="0 4 * * *"
 
 ENTRYPOINT ["/init"]
 
@@ -22,6 +25,7 @@ RUN \
       uuid-runtime \
       unrar \
       rsync \
+      cron \
     && \
 
 # Fetch and extract S6 overlay

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,6 +9,9 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
     SYNC_STATUS_FILE="/etc/services.d/plex/data/syncing"
+ENV PLEX_PORT=32400 \
+    X_PLEX_TOKEN= \
+    PERSISTENT_CONFIG_CRON="0 4 * * *"
 
 ENTRYPOINT ["/init"]
 
@@ -22,6 +25,7 @@ RUN \
       uuid-runtime \
       unrar \
       rsync \
+      cron \
     && \
 
 # Fetch and extract S6 overlay

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -9,6 +9,9 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENV HOME="/config" \
     HOME_PERSISTENT="/config_persistent" \
     SYNC_STATUS_FILE="/etc/services.d/plex/data/syncing"
+ENV PLEX_PORT=32400 \
+    X_PLEX_TOKEN= \
+    PERSISTENT_CONFIG_CRON="0 4 * * *"
 
 ENTRYPOINT ["/init"]
 
@@ -22,6 +25,7 @@ RUN \
       uuid-runtime \
       unrar \
       rsync \
+      cron \
     && \
 
 # Fetch and extract S6 overlay

--- a/root/etc/services.d/cron/run
+++ b/root/etc/services.d/cron/run
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv bash
+
+exec cron -f

--- a/root/etc/services.d/plex/run
+++ b/root/etc/services.d/plex/run
@@ -4,8 +4,19 @@ if /usr/local/bin/home_persistent_mounted; then
   if [ ! -f "$HOME_PERSISTENT/.last_clean" ]; then
     flock "$SYNC_STATUS_FILE" /usr/local/bin/initial_storage
   fi
+
   flock "$SYNC_STATUS_FILE" /usr/local/bin/sync_to_local
   flock "$SYNC_STATUS_FILE" /usr/local/bin/purge_persistent &
+
+  > "/etc/cron.d/persistent_config"
+  IFS=':'
+  read -ra persistent_config_cron <<< "$PERSISTENT_CONFIG_CRON"
+  for i in "${persistent_config_cron[@]}"; do
+    echo "$i root /usr/local/bin/periodic_sync" >> "/etc/cron.d/persistent_config"
+  done
+  IFS=' '
+
+  s6-svc -u "$(ps ax | awk '{ if ( $1 == 1 ) print $NF }')/cron"
 fi
 
 echo "Starting Plex Media Server."

--- a/root/usr/local/bin/periodic_sync
+++ b/root/usr/local/bin/periodic_sync
@@ -1,0 +1,8 @@
+#!/usr/bin/with-contenv bash
+
+if curl -sGd X-Plex-Token=${X_PLEX_TOKEN} http://localhost:${PLEX_PORT}/status/sessions | grep '<MediaContainer size="0">' &> /dev/null; then
+  echo "Restarting Plex Media Server for periodic sync."
+  s6-svc -r "$(ps ax | awk '{ if ( $1 == 1 ) print $NF }')/plex"
+else
+  echo "Plex Media Server is active; no periodic sync."
+fi


### PR DESCRIPTION
By adding X_PLEX_TOKEN, PLEX_PORT, and PERSISTENT_CONFIG_CRON environment variables, the server's status will be automatically checked at the scheduled time(s); it will be restarted if it isn't currently serving media.

X_PLEX_TOKEN is necessary and self-explanatory.
PLEX_PORT is the server's port (32400 by default).
PERSISTENT_CONFIG_CRON is the cron-formatted schedule for the checks/restarts. It is is "0 4 * * *" (4am every day) by default; multiple entries can be made by separating them with a ':'.